### PR TITLE
Add a generic API to get/set the tags using a tag name and a tag value

### DIFF
--- a/taglib.go
+++ b/taglib.go
@@ -8,15 +8,88 @@ import "C"
 
 import (
 	"errors"
+	"strconv"
 	"sync"
 	"time"
 	"unsafe"
+)
+
+type TagName int
+
+// Tag names
+const (
+	Album TagName = iota
+	Artist
+	Bitrate
+	Channels
+	Comments
+	Genre
+	Length
+	Samplerate
+	Title
+	Track
+	Year
 )
 
 var (
 	ErrInvalid = errors.New("invalid file")
 	glock      = sync.Mutex{}
 )
+
+// Returns a string with this tag's comment.
+func (file *File) Tag(tagname TagName) (tagvalue string) {
+	switch tagname {
+	case Album:
+		return file.Album()
+	case Artist:
+		return file.Artist()
+	case Bitrate:
+		return strconv.Itoa(file.Bitrate())
+	case Channels:
+		return strconv.Itoa(file.Channels())
+	case Comments:
+		return file.Comment()
+	case Genre:
+		return file.Genre()
+	case Length:
+		return file.Length().String()
+	case Samplerate:
+		return strconv.Itoa(file.Samplerate())
+	case Title:
+		return file.Title()
+	case Track:
+		return strconv.Itoa(file.Track())
+	case Year:
+		return strconv.Itoa(file.Year())
+	}
+	return ""
+}
+
+// Sets the tag.
+func (file *File) SetTag(tagname TagName, tagvalue string) {
+	switch tagname {
+	case Album:
+		file.SetAlbum(tagvalue)
+	case Artist:
+		file.SetArtist(tagvalue)
+	case Comments:
+		file.SetComment(tagvalue)
+	case Genre:
+		file.SetGenre(tagvalue)
+	case Title:
+		file.SetTitle(tagvalue)
+	case Track:
+		intValue, convErr := strconv.Atoi(tagvalue)
+		if convErr == nil {
+			file.SetTrack(intValue)
+		}
+	case Year:
+		intValue, convErr := strconv.Atoi(tagvalue)
+		if convErr == nil {
+			file.SetYear(intValue)
+		}
+	}
+}
 
 type File struct {
 	fp    *C.TagLib_File

--- a/taglib.go
+++ b/taglib.go
@@ -1,4 +1,8 @@
 // Go wrapper for taglib
+
+// Generate stringer method for types
+//go:generate stringer -type=TagName
+
 package taglib
 
 // #cgo LDFLAGS: -ltag_c
@@ -306,3 +310,4 @@ func (file *File) SetTrack(i int) {
 	ci := C.uint(i)
 	C.taglib_tag_set_track(file.tag, ci)
 }
+


### PR DESCRIPTION
Add a generic API to handle tags using a tag name and a tag value.
Allows to write generic code to handle different tags.
The test code has also been updated. 